### PR TITLE
Fix memory issue with dense matrix while calculating triad census

### DIFF
--- a/R/signed_triangles.R
+++ b/R/signed_triangles.R
@@ -406,7 +406,7 @@ triad_census_signed <- function(g){
     "300-NPNPNP", "300-PNNPPN", "300-NNNNPP", "300-NNNPNP",
     "300-NNNPPN", "300-NPNPNN", "300-NNNNNP", "300-NNNNNN")
 
-  A <- as_adj_signed(g,sparse = FALSE)#
+  A <- as_adj_signed(g, sparse = TRUE)
   n <- nrow(A)
   adj <- igraph::as_adj_list(igraph::as.undirected(g),"all")
   adj <- lapply(adj,function(x) x-1)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -158,12 +158,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // triadCensusSign1
-IntegerVector triadCensusSign1(NumericMatrix A, List adj, int n);
+DoubleVector triadCensusSign1(const arma::sp_mat &A, List adj, int n);
 RcppExport SEXP _signnet_triadCensusSign1(SEXP ASEXP, SEXP adjSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< NumericMatrix >::type A(ASEXP);
+    Rcpp::traits::input_parameter< const arma::sp_mat& >::type A(ASEXP);
     Rcpp::traits::input_parameter< List >::type adj(adjSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     rcpp_result_gen = Rcpp::wrap(triadCensusSign1(A, adj, n));

--- a/src/triadCensus.cpp
+++ b/src/triadCensus.cpp
@@ -1,18 +1,24 @@
-// [[Rcpp::depends(RcppArmadillo)]]
 #include <RcppArmadillo.h>
+// [[Rcpp::depends(RcppArmadillo)]]
 using namespace Rcpp;
 
-// [[Rcpp::export]]
-IntegerVector triadCensusSign(NumericMatrix A, int n){
 
-  int code=0;
+// [[Rcpp::export]]
+IntegerVector triadCensusSign(NumericMatrix A, int n)
+{
+
+  int code = 0;
   IntegerVector triads(729);
 
-  for(int u=0;u<n;++u){
-    for(int v=0;v<n;++v){
-      for(int w=0;w<n;++w){
-        if((u<v) & (v<w)){
-          code = A(u,v)+3*A(u,w)+9*A(v,u)+27*A(v,w)+81*A(w,u)+243*A(w,v);
+  for (int u = 0; u < n; ++u)
+  {
+    for (int v = 0; v < n; ++v)
+    {
+      for (int w = 0; w < n; ++w)
+      {
+        if ((u < v) & (v < w))
+        {
+          code = A(u, v) + 3 * A(u, w) + 9 * A(v, u) + 27 * A(v, w) + 81 * A(w, u) + 243 * A(w, v);
           triads[code] = triads[code] + 1;
         }
       }
@@ -22,26 +28,31 @@ IntegerVector triadCensusSign(NumericMatrix A, int n){
 }
 
 // [[Rcpp::export]]
-IntegerVector triadCensusSign1(NumericMatrix A, List adj, int n){
-
-  int code=0;
-  IntegerVector triads(729);
-  for(int u=0;u<n;u++){
+DoubleVector triadCensusSign1(const arma::sp_mat &A, List adj, int n)
+{
+  long long code = 0;
+  DoubleVector triads(729);
+  for (int u = 0; u < n; u++)
+  {
     IntegerVector Nu = as<IntegerVector>(adj[u]);
     int nu = Nu.length();
-    for(int j=0;j<nu;j++){
+    for (int j = 0; j < nu; j++)
+    {
       int v = Nu[j];
-      if(u<v){
+      if (u < v)
+      {
         IntegerVector Nv = as<IntegerVector>(adj[v]);
-        IntegerVector S = union_(Nu,Nv);
-        IntegerVector uv = {u,v};
-        S = setdiff(S,uv);
-        code = (A(u,v) + 1)+3+9*(A(v,u) + 1)+27+81+243;
-        triads[code] = triads[code] + n-S.length()-2;
-        for(int k=0;k<S.length();k++){
+        IntegerVector S = union_(Nu, Nv);
+        IntegerVector uv = {u, v};
+        S = setdiff(S, uv);
+        code = (A(u, v) + 1) + 3 + 9 * (A(v, u) + 1) + 27 + 81 + 243;
+        triads[code] = triads[code] + n - S.length() - 2;
+        for (int k = 0; k < S.length(); k++)
+        {
           int w = S[k];
-          if( (v<w) | ((u<w) & (w<v) & (A(u,w)==0) & (A(w,u)==0))){
-            code = (A(u,v)+1)+3*(A(u,w)+1)+9*(A(v,u)+1)+27*(A(v,w)+1)+81*(A(w,u)+1)+243*(A(w,v)+1);
+          if ((v < w) | ((u < w) & (w < v) & (A(u, w) == 0) & (A(w, u) == 0)))
+          {
+            code = (A(u, v) + 1) + 3 * (A(u, w) + 1) + 9 * (A(v, u) + 1) + 27 * (A(v, w) + 1) + 81 * (A(w, u) + 1) + 243 * (A(w, v) + 1);
             triads[code] = triads[code] + 1;
           }
         }
@@ -50,5 +61,4 @@ IntegerVector triadCensusSign1(NumericMatrix A, List adj, int n){
   }
   return triads;
 }
-
 


### PR DESCRIPTION
Many thanks for the great package!

While I was calculating the triad census for the signed directed network with size 50000, I encountered the problem with memory. I decided to change a dense matrix into the sparse one and now it works without any issue.

I also changed NumericVector into the DoubleVector due to the integer overflow. 